### PR TITLE
update readme instruction for missing method argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Parameters:
 
 We can convert synthetic data in histogram representation to matrix tabular representation.
 ```
-table = Tabular(mw.synthetic)
+table = Tabular(mw.synthetic, n)
 ```
 Compute error achieved by MWEM:
 ```


### PR DESCRIPTION
I got this error when following through the demo in the readme:

```
julia> Tabular(mw.synthetic)
ERROR: `convert` has no method matching convert(::Type{Array{Float64,2}}, ::Histogram)
 in Tabular at no file
```

Calling it with `Tabular(mw.synthetic, n)` where `n = 1000` from earlier seem to make the example to work.
