### PR TITLE
Update code for julia 1.0.0 + addings and little changed definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Available parameters:
 | `iterations` | `10` | Number of iterations of MWEM. Each iteration corresponds to selecting one query via the exponential mechanism, evaluating the query on the data, and updating the internal state. |
 | `repetitions`| `10` | Number of times MWEM cycles through previously measured queries per iteration. This has no additional privacy cost. |
 | `noisy_init` | `false` | This requires part of the `epsilon` privacy cost.  When `noisy_init` is set to false, the initialization is uniform.  |
-| `init_budget` | `=0.5` | In case the `noisy_init` flag is set to true, this flag decide what fraction of the `epsilon` privacy cost will be given for the noisy initialization. When `noisy_init` is set to false, all the budget will be used by the iterations. |
+| `init_budget` | `0.5` | In case the `noisy_init` flag is set to true, this flag decide what fraction of the `epsilon` privacy cost will be given for the noisy initialization. When `noisy_init` is set to false, all the budget will be used by the iterations. |
 | `noisy_max_budget` | `0.05` | Decise what fraction from the `epsion` privacy badget of every iteration will go to the "noisy max" step. (the rest is for the Exponential Mechanism)  |
 | `verbose` | `false` | print timing and error statistics per iteration (information is not differentially private)
 

--- a/README.md
+++ b/README.md
@@ -74,16 +74,20 @@ mw = mwem(Parities(d, 3),
                        iterations=10,
                        repetitions=10,
                        verbose=false,
-                       noisy_init=false))
+                       noisy_init=false,
+                       init_budget=0.05,
+                       noisy_max_budget=0.5))
 ```
 Available parameters:
 
 | Name | Default | Description |
 | ---- | ------- | ----------- |
-| `epsilon` | `1.0` | Privacy parameter per iteration. Each iteration of MWEM is `epsilon`-differentially private. Total privacy guarantees follow via composition theorems. |
+| `epsilon` | `1.0` | Privacy parameter for the algorithm. MWEM is `epsilon`-differentially private. Each iteration of MWEM is `epsilon`/`iterations`-differentially private. Total privacy guarantees follow via composition theorems.|
 | `iterations` | `10` | Number of iterations of MWEM. Each iteration corresponds to selecting one query via the exponential mechanism, evaluating the query on the data, and updating the internal state. |
 | `repetitions`| `10` | Number of times MWEM cycles through previously measured queries per iteration. This has no additional privacy cost. |
-| `noisy_init` | `false` | Histogram initalization through noise addition.  This incurs an additional `epsilon` privacy cost.  When `noisy_init` is set to false, the initialization is uniform.  |
+| `noisy_init` | `false` | This requires part of the `epsilon` privacy cost.  When `noisy_init` is set to false, the initialization is uniform.  |
+| `init_budget` | `=0.5` | In case the `noisy_init` flag is set to true, this flag decide what fraction of the `epsilon` privacy cost will be given for the noisy initialization. When `noisy_init` is set to false, all the budget will be used by the iterations. |
+| `noisy_max_budget` | `0.05` | Decise what fraction from the `epsion` privacy badget of every iteration will go to the "noisy max" step. (the rest is for the Exponential Mechanism)  |
 | `verbose` | `false` | print timing and error statistics per iteration (information is not differentially private)
 
 The function `MWParameters` accepts any subset of parameters, e.g.,
@@ -146,9 +150,14 @@ See `src/parities.jl` for an example.
 
   Parities of `k` out of `d` attributes for factored histogram representation.
 
-- **RangeQueries**(N)
+- **SeriesRangeQueries**(N)
 
   Range queries corresponding to all interval queries over a histogram of length `N`.
+  
+  - *SeriesRangeQueries**(Intervals)
+
+  Range queries over histogram with length N, corresponding to intervals = {Interval1, Interval2, ...}
+  where Interval = (i, j) so that 1 <= i <= j <= N.
 
 ## Contributing to this package
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,8 @@
-julia 0.4
+julia 1.0.0
 Distributions
 Hadamard
-Iterators
+Printf
+LinearAlgebra
+IterTools
+Statistics
+Distributed

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ LinearAlgebra
 IterTools
 Statistics
 Distributed
+DataFrames

--- a/examples/DataAccessibility.jl
+++ b/examples/DataAccessibility.jl
@@ -1,0 +1,174 @@
+using DataFrames
+
+"""
+translate the element (row in the dataset) to index in the 
+histogram of the domain, according to the columns dimension sizes.
+params:
+    element:    iterable that contain the values of the its columns.
+    domains:    the domain sizes of the columns.
+"""
+function get_flatten_index(element, domains)
+    counter = 0
+    pow = 1
+    for (i,s) in zip(element,domains)
+        counter += i*pow
+        pow *= s
+    end
+    counter
+end
+
+"""
+translate the index in the histogram of the domain to the corresponding 
+element in the dataset (row in the dataset), according to the columns dimension sizes.
+params:
+    index:    index in the histogram (integer).
+    domains:    the domain sizes of the columns.
+"""
+function reverse_flatten_index(index, dim)
+
+    new_index = zeros(Int64, length(dim))
+
+    for (i,s) in enumerate(dim)
+        new_index[i] += index % s
+        index -= index % s
+        index /= s
+    end
+
+    new_index
+
+end
+
+"""
+get a list of values, and return how many times the each value is found.
+return: dictionary{value : counter}
+"""
+function countMembers(itr)
+    d = Dict{eltype(itr), Int64}()
+    for val in itr
+        if isa(val, Number) && isnan(val)
+            continue
+        end
+        d[val] = get!(d, val, 0) + 1
+    end
+    return d
+end
+
+"""
+create a mapping for the elements of a domain, into integers
+    params:
+        domain_elements:    the elements of the domain
+    return:
+        A tuple of two mappings: (index => elemnt, elemnt => index)
+"""
+function getMapping(domain_elements::Array)
+
+    direct_mapping = Dict{Int64, Any}()
+    reverse_mapping2 = Dict{Any, Int64}()
+
+    for (i,element) in enumerate(domain_elements)
+        direct_mapping[i-1] = element
+        reverse_mapping2[element] = i-1
+    end
+
+    direct_mapping, reverse_mapping2
+
+end
+
+"""
+Get a dataset and make it into a histogram of its domain.
+    params:
+        data:               A dataframe containing the dataset
+        domain_elements:    list of the domain elements of every column (a list of lists)
+    return:
+        histogram:  the histogram of the dataset over the domain.
+        mapping:    a list of tuples of mappings (index => elemnt, elemnt => index) for every column domain.
+"""
+function createHistogram(data::DataFrames.DataFrame, domains_elements::Array)
+
+    n, d = size(data)
+
+    domain_sizes = [length(domain)  for domain in domains_elements]
+    histogram_size = prod(domain_sizes)
+
+    histogram = zeros(Float64, histogram_size)
+
+    mappings = []
+
+    for domain_elements in domains_elements
+        push!(mappings, getMapping(domain_elements))
+    end
+    
+    for i = 1:n
+        x = [data[i,j] for j=1:d]
+        index = [mappings[j][2][x[j]] for j=1:d]
+        histogram_index = get_flatten_index(index, domain_sizes) + 1
+        histogram[histogram_index] += 1
+    end
+
+    histogram, mappings
+
+end
+
+""""
+create histogram from a matrix of data.
+"""
+function createHistogram(data::AbstractArray, domains_elements::Array)
+
+    createHistogram(DataFrame(samples), domains_elements)
+
+end
+
+"""
+Recreate a database from histogram according to the mapping of the original elements of the dataset domain.
+(the mapping from the creating of the histogram. see "createHistogram" function)
+params:
+    histogram:  a histogram of a dataset.
+    mapping:    a list of tuples of mappings (index => elemnt, elemnt => index) for every column domain of the dataset.
+    domain_elements:    list of the domain elements of every column (a list of lists)
+
+return:
+    df: A dataframe containing the recreated dataset
+"""
+function recreateDataset(histogram::Array{Float64, 1}, mappings::Array, domains_elements::Array)
+
+    n = sum(histogram)
+    d = length(domains_elements)
+
+    domain_sizes = [length(domain)  for domain in domains_elements]
+
+    df = DataFrame()
+    for i=1:d
+        df[i] = []
+    end
+
+    for index = 1:length(histogram)
+        domain_element_encoded = reverse_flatten_index(index-1, domain_sizes)
+        domain_element = [mappings[j][1][domain_element_encoded[j]] for j=1:d]
+        for i=1:histogram[index]
+            push!(df, copy(domain_element))
+        end
+    end
+
+    df
+
+end
+
+function readContingencyTable(data::DataFrames.DataFrame, dimension::Int64)
+
+    @assert length(size(data)) == 2
+
+    n,temp = size(data)
+
+    @assert temp == 2
+    @assert n > 0
+
+    hist = zeros(Float64, 2^dimension)
+
+    for i in 1:n
+        dig = digits(data[[:1]][1][i], base = 10)
+        index = sum([dig[k]*2^(k-1) for k=1:length(dig)])
+        hist[index] += data[[:2]][1][i]
+    end
+
+    hist
+end

--- a/examples/histograms.ipynb
+++ b/examples/histograms.ipynb
@@ -136,7 +136,7 @@
     }
    ],
    "source": [
-    "mw = mwem(RangeQueries(domain_size), Histogram(ys/sum(ys), num_samples));\n",
+    "mw = mwem(SeriesRangeQueries(domain_size), Histogram(ys/sum(ys), num_samples));\n",
     "bar(xs, mw.synthetic.weights*num_samples, align=\"center\", color=\"red\", alpha=0.3, width=1/domain_size);"
    ]
   },
@@ -166,7 +166,7 @@
     }
    ],
    "source": [
-    "mw = mwem(RangeQueries(domain_size), Histogram(ys/sum(ys), num_samples), MWParameters(epsilon=0.1, iterations=8));\n",
+    "mw = mwem(SeriesRangeQueries(domain_size), Histogram(ys/sum(ys), num_samples), MWParameters(epsilon=0.1, iterations=8));\n",
     "bar(xs, mw.synthetic.weights*num_samples, align=\"center\", color=\"red\", alpha=0.3, width=1/domain_size);"
    ]
   },

--- a/examples/marginals.jl
+++ b/examples/marginals.jl
@@ -15,7 +15,7 @@ end
 function range_queries()
     histogram = vcat(zeros(100), ones(100), zeros(100))
     data = Histogram(histogram, 100)
-    mwem(RangeQueries(300), data, MWParameters(repetitions=100, verbose=true))
+    mwem(SeriesRangeQueries(300), data, MWParameters(repetitions=100, verbose=true))
 end
 
 print("Elapsed time: ", @elapsed marginals())

--- a/src/PrivateMultiplicativeWeights.jl
+++ b/src/PrivateMultiplicativeWeights.jl
@@ -1,10 +1,15 @@
 module PrivateMultiplicativeWeights
 
 using
-    Distributions.Laplace,
-    Distributions.wsample,
+    Distributions: Laplace, wsample
+using
+    Printf,
     Hadamard,
-    Iterators.subsets
+    LinearAlgebra,
+    Random,
+    IterTools,
+    Statistics,
+    Distributed,
 
 export
     mwem,
@@ -12,14 +17,34 @@ export
     Tabular,
     Histogram,
     HistogramQueries,
+    SeriesRangeQueries,
     RangeQueries,
+    RangeQuery,
     Parities,
     FactorParities,
+    Interval,
+    gosper,
+    BinaryItr,
+    
     maximum_error,
-    mean_squared_error
+    kl_divergence_error,
+    mean_squared_error,
+    queriesMatrix,
+
+    evaluate,
+    get,
+
+    kl_divergence,
+    complete_way_marginals_indices,
+    fourierCoefficients,
+    calculateMarginal,
+    Marginals,
+
+    get_query_vector_from_interval,
+    hadamard_basis_vector
 
 import
-    Base: start, next, done, eltype, length
+    Base: eltype, length, iterate
 
 include("interface.jl")
 include("histogram.jl")

--- a/src/error.jl
+++ b/src/error.jl
@@ -5,7 +5,7 @@ Compute maximum error of synthetic data on the query set. Result is not
 differentially private.
 """
 function maximum_error(mw::MWState)
-    maximum(abs(evaluate(mw.queries, mw.synthetic) - mw.real_answers))
+    norm(evaluate(mw.queries, mw.synthetic) - mw.real_answers, Inf)
 end
 
 """
@@ -15,8 +15,15 @@ Compute mean_squared_error of synthetic data on the query set. Result is not
 differentially private.
 """
 function mean_squared_error(mw::MWState)
+
     errors = evaluate(mw.queries, mw.synthetic) - mw.real_answers
-    norm(errors)^2/length(errors)
+    (norm(errors)^2)/length(errors)
+end
+
+function total_squared_error(mw::MWState)
+
+    errors = evaluate(mw.queries, mw.synthetic) - mw.real_answers
+    (norm(errors)^2)/length(errors)
 end
 
 """
@@ -29,9 +36,16 @@ function kl_divergence(a::Array{Float64, 1}, b::Array{Float64, 1})
     for i = 1 : length(a)
         @inbounds ai = a[i]
         @inbounds bi = b[i]
-        if ai > 0
+        if ai > 0 && bi > 0
             r += ai * log(2, ai / bi)
         end
     end
     r
+end
+
+function kl_divergence_error(mw::MWState)
+
+    #error = kl_divergence(mw.synthetic.weights, mw.real.weights)
+    error = kl_divergence(mw.real.weights, mw.synthetic.weights)
+    error
 end

--- a/src/factors.jl
+++ b/src/factors.jl
@@ -1,4 +1,8 @@
-type Factor
+abstract type FactorHistogramQuery <: Query end
+
+abstract type FactorHistogramQueries <: Queries end
+
+mutable struct Factor
     attributes::Array{Int, 1}
     histogram::Histogram
 end
@@ -6,18 +10,14 @@ end
 """
     FactorHistogram
 
-FactorHistogram represents the data as a product of histograms on disjoint 
+FactorHistogram represents the data as a product of histograms on disjoint
 attributes. This corresponds to a distribution where variables in different
 factors are independent.
 """
-type FactorHistogram <: Data
+struct FactorHistogram <: Data
     factors::Array{Factor, 1}
     lookup::Dict{Int, Int}
 end
-
-abstract FactorHistogramQuery <: Query
-
-abstract FactorHistogramQueries <: Queries
 
 function attributes(q::FactorHistogramQuery)
     throw("`attributes` not implemented for `$(typeof(q))`.")

--- a/src/gosper.jl
+++ b/src/gosper.jl
@@ -1,4 +1,4 @@
-immutable GosperIterator
+struct GosperIterator
     n::Int64
     k::Int64
 end
@@ -17,7 +17,7 @@ function gosper(n::Int, k::Int)
     return GosperIterator(n, k)
 end
 
-typealias GosperState Tuple{Int64, Int64}
+const GosperState = Tuple{Int64, Int64}
 
 eltype(it::GosperIterator) = Int64
 length(it::GosperIterator) = binomial(it.n, it.k)
@@ -26,14 +26,122 @@ function start(it::GosperIterator)
     (2^(it.k) - 1, 2^(it.n) -1)
 end
 
-function next(it::GosperIterator, state::GosperState)
-    # Gosper's hack: Finds the next smallest number with exactly k bits
+function iterate(it::GosperIterator, state::GosperState = start(it))
+
+    if state[1] > state[2]
+        return nothing
+    end
+
+        # Gosper's hack: Finds the next smallest number with exactly k bits
     # set to 1 in its binary representation.
     o = state[1]
     u = state[1] & -state[1]
     v = u + state[1]
-    y = v + (div(v $ state[1], u) >> 2)
+    y = v + (div(xor(v, state[1]), u) >> 2)
     return o, (y, state[2])
 end
 
-done(it::GosperIterator, state::GosperState) = state[1] > state[2]
+
+struct BinaryIndexIterator
+    d::Int64#  dimension
+    indices::Array{Int64}# indices of 1's
+    init_value::Int64# value that the iterator add the subnumbers to it
+end
+
+"""
+For some a in {0,1}^d, that have 1's in the places "indices", iterate over all substes 
+of indices in "indices" and return the number of it's binary representation
+"""
+function BinaryItr(d::Int64, indices::Array{Int64}, init_value::Int64 = 0)
+    @assert 0 < d <= 62
+
+    BinaryIndexIterator(d, indices, init_value)
+end
+
+"""
+Now the indices of the 1's are the number itself with those indices
+"""
+function BinaryItr(d::Int64, indices::Int64, init_value::Int64 = 0)
+    @assert 0 < d <= 62
+
+    _, arr_idx = norm_1_with_indices(indices)
+
+    BinaryIndexIterator(d, Array{Int64}(arr_idx), init_value)
+end
+
+const BinaryIndexState = Int64
+
+eltype(it::BinaryIndexIterator) = Int64
+length(it::BinaryIndexIterator) = 2^(length(it.indices))
+
+function start(it::BinaryIndexIterator)
+   0
+end
+
+function iterate(it::BinaryIndexIterator, state::BinaryIndexState = start(it))
+
+    if state == length(it)
+        return nothing
+    end
+
+    sub_binary_number = it.init_value
+
+    temp_state = state
+
+    for i=1:length(it.indices)
+        if temp_state == 0
+            break
+        end
+        if temp_state%2 == 1
+            sub_binary_number += 1<<(it.indices[i]-1)
+        end
+        temp_state >>= 1
+    end
+
+    state += 1
+
+    return sub_binary_number, state
+
+end
+
+"""
+Calculate the norm1 of binary number (the number of 1's in the number).
+return: -norm1(alpha)
+        -array with the indices of the 1's
+"""
+function norm_1_with_indices(alpha::Int64)
+
+    @assert alpha >= 0
+
+    count = 0
+    index = 1
+    idx = []
+    while alpha > 0
+        if alpha % 2 == 1
+            count += 1
+            push!(idx, index)
+        end
+        alpha >>= 1
+        index += 1
+    end
+    count, Array{Int64}(idx)
+end
+
+"""
+Calculate the norm1 of binary number (the number of 1's in the number).
+return: -norm1(alpha)
+        -array with the indices of the 1's
+"""
+function norm_1(alpha::Int64)
+
+    @assert alpha >= 0
+
+    count = 0
+    while alpha > 0
+        if alpha % 2 == 1
+            count += 1
+        end
+        alpha >>= 1
+    end
+    count
+end

--- a/src/histogram.jl
+++ b/src/histogram.jl
@@ -4,7 +4,7 @@
 Histogram represents the data as a vector where each coordinate corresponds to
 one element of the data universe. This is the default representation for MWEM.
 """
-type Histogram <: Data
+mutable struct Histogram <: Data
     weights::Array{Float64, 1}
     num_samples::Int64
 end
@@ -13,11 +13,11 @@ function Histogram(weights::Array{Float64, 1})
     Histogram(weights, 0)
 end
 
-type HistogramQuery <: Query
+struct HistogramQuery <: Query
     weights::Array{Float64, 1}
 end
 
-type HistogramQueries <: Queries
+struct HistogramQueries <: Queries
     queries::Array{Float64, 2}
 end
 
@@ -38,10 +38,11 @@ function normalize!(h::Histogram)
     h
 end
 
-# if error is > 0, increase weight on positive elements of queries[query] and 
+# if error is > 0, increase weight on positive elements of queries[query] and
 # decrease weight on negative elements. Magnitude of error determines step size.
 function update!(q::HistogramQuery, h::Histogram, error::Float64)
-    @simd for j = 1:length(h.weights)
+
+    Threads.@threads for j = 1:length(h.weights)# @threads can help to speed up
         @inbounds h.weights[j] *= exp(error * q.weights[j] / 2.0)
     end
     normalize!(h)
@@ -53,19 +54,21 @@ function initialize(queries::Queries, data::Histogram, ps::MWParameters)
     num_samples = data.num_samples
     if ps.noisy_init
         # Noisy init incurs an additional `epsilon` privacy cost
-        weights = Array(Float64, histogram_length)
-        noise = rand(Laplace(0.0, 1.0/(ps.epsilon*num_samples)), histogram_length)
+        weights = zeros(Float64, histogram_length)
+        noise = rand(Laplace(0.0, 1/(num_samples*ps.epsilon*ps.init_budget)), histogram_length)
         @simd for i = 1:histogram_length
-             @inbounds weights[i] = 
+             @inbounds weights[i] =
                  max(data.weights[i] + noise[i] - 1.0/(e*num_samples*ps.epsilon), 0.0)
         end
         weights /= sum(weights)
         synthetic = Histogram(0.5 * weights + 0.5/histogram_length)
+        ps.epsilon = (1-ps.init_budget)*ps.epsilon
     else
-        synthetic = Histogram(ones(histogram_length)/histogram_length)
+        weights = ones(Float64, histogram_length)
+        synthetic = Histogram(weights/histogram_length)
     end
     real_answers = evaluate(queries, data)
-    scale = 2.0/(ps.epsilon*num_samples)
+    scale = (ps.iterations)/(ps.epsilon*num_samples)
     MWState(data, synthetic, queries, real_answers, Dict{Int, Float64}(), scale)
 end
 
@@ -81,12 +84,12 @@ Create histogram representation from tabular data.
 """
 function Histogram(table::Tabular)
     d, n = size(table.data)
-    histogram = zeros(2^d)
+    histogram = zeros(Float64,2^d)
     for i = 1:n
         num = 0
         x = vec(table.data[:, i])
-        for i = 1:d
-            num += convert(Int64, x[d-i+1]) * 2^(i-1)
+        for j = 1:d
+            num += convert(Int64, x[d-j+1]) * 2^(j-1)
         end
         histogram[num+1] += 1.0
     end
@@ -104,7 +107,8 @@ function Tabular(histogram::Histogram, n::Int)
     idx = wsample(collect(0:N-1), histogram.weights, n)
     data_matrix = zeros(d, n)
     for i = 1:n
-        data_matrix[:, i] = reverse(digits(idx[i], 2, d))
+        #println(idx[i], 2, d)
+        data_matrix[:, i] = reverse(digits(idx[i], base = 2, pad = d))
     end
     Tabular(data_matrix)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,12 +1,13 @@
-abstract Data
-abstract Query
-abstract Queries
+abstract type Data end
+abstract type Query end
+abstract type Queries end
 
 
-typealias QueryIndex Int
+const QueryIndex = Int
+const Interval = Tuple{Int64, Int64}
 
 
-type MWState
+struct MWState
     real::Data
     synthetic::Data
     queries::Queries
@@ -16,16 +17,18 @@ type MWState
 end
 
 
-type MWParameters
-   epsilon::Float64
-   iterations::Int64
-   repetitions::Int64
-   noisy_init::Bool
-   verbose::Bool
+struct MWParameters
+    epsilon::Float64
+    iterations::Int64
+    repetitions::Int64
+    noisy_init::Bool
+    verbose::Bool
+    init_budget::Float64
+    noisy_max_budget::Float64
 end
 
 
-type Tabular <: Data
+struct Tabular <: Data
     data::Array{Float64, 2}
 end
 
@@ -85,7 +88,7 @@ end
    normalize!(d::Data)
 
 Normalizes data.
-"""   
+"""
 function normalize!(d::Data)
     throw("`normalize!` not implemented for `$(typeof(d))`.")
 end

--- a/src/parities.jl
+++ b/src/parities.jl
@@ -3,8 +3,16 @@
 
 Implementation of parity queries using Fast Hadamard Walsh Transform and Gosper
 iteration.
+
+Releasing privacy prserving marginals for contingency table.
+The measurments in this case are not the marginals, but the fourier coefficients of the contingency table,
+that are sufficient for recovering the marginals.
+
+Details can be found in:
+"B. Barak, K. Chaudhuri, C. Dwork, S. Kale,F. McSherry, and K. Talwar. 
+Privacy, accuracy, and consistency too: a holistic solution to contingency table release. In PODS, 2007."
 """
-type Parities <: Queries
+struct Parities <: Queries
     dimension::Int
     order::Int
     idx::Array{Int, 1}
@@ -16,7 +24,7 @@ end
 Returns hadamard basis vector given by `index`.
 """
 function hadamard_basis_vector(index::Int, dimension::Int)
-    hadamard = Array(Float64, 1 << dimension)
+    hadamard = zeros(Float64, 1 << dimension)
     hadamard[1] = 1.0
     for i = 0:dimension-1
         sign = (index & (1 << i)) > 0 ? -1.0 : 1.0
@@ -27,30 +35,106 @@ function hadamard_basis_vector(index::Int, dimension::Int)
     hadamard
 end
 
-function Parities(dimension, order)
-    idx = [1]
-    for r = 1:order
-        for s = gosper(dimension, r)
-            push!(idx, s+1)
+"""
+return the downward closure of all the incides of the k-way marginals, of dimension d.
+
+# Example:
+    k = 2, d = 4
+    k-way indices= [0011, 0101, 0110, 1001, 1010, 1100]
+    downward_closure(0011) = [0000, 0001, 0010, 0011]
+"""
+function complete_way_marginals_indices(k::Int64, d::Int64)
+    
+    idx = Set(zeros(Int64, 0))
+    
+    for s = gosper(d, k)
+        for alpha in BinaryItr(d, s)
+            temp = alpha + 1
+            push!(idx, temp)
         end
     end
-    Parities(dimension, order, idx)
+
+    sort(collect(idx))
+end
+
+
+function Parities(dimension, order)
+    Parities(dimension, order, complete_way_marginals_indices(order, dimension))
 end
 
 function get(queries::Parities, i::Int)
     HistogramQuery(hadamard_basis_vector(queries.idx[i]-1, queries.dimension))
 end
 
+"""
+evaluate the measurements of the linear queries defined by 
+queries.idx (the indices needed for calculating the marginals of the contingency table)
+"""
 function evaluate(queries::Parities, h::Histogram)
     2^queries.dimension * fwht_natural(h.weights)[queries.idx]
+end
+
+function fourierCoefficients(queries::Parities, h::Histogram)
+    2^queries.dimension * fwht_natural(h.weights)
+end
+
+"""
+Calculate the marginal C_beta : R^(2^d) -> R^(2^(norm1(beta))), for beta in {0,1}^d, 
+of the fourier basis vector in the location alpha
+"""
+function fourierMarginal(dimension::Int64, beta::Int64, alpha::Int64)
+
+    @assert beta & alpha == alpha
+
+    beta_norm1, beta_indices = norm_1_with_indices(beta)
+    alpha_norm1, alpha_indices = norm_1_with_indices(alpha)
+
+    marginal = zeros(Int64, 2^beta_norm1)
+
+    inverse_beta = setdiff(collect(1:dimension), beta_indices)
+
+    for (gamma_index, gamma) in enumerate(BinaryItr(dimension, beta))
+        marginal[gamma_index] = 2^length(inverse_beta)*((-1)^(norm_1(alpha&gamma)))
+    end
+
+    marginal
+end
+
+"""
+Calculate the marginal C_beta : R^(2^d) -> R^(2^(norm1(beta))), for beta in {0,1}^d, 
+of the contingencyTable (represent as histogram).
+"""
+function calculateMarginal(queries::Parities, h::Histogram, beta::Int64)
+
+    beta_norm1, beta_indices = norm_1_with_indices(beta)
+
+    marginal = zeros(Int64, 2^beta_norm1)
+
+    coefficients = fourierCoefficients(queries, h)
+
+    for alpha in BinaryItr(queries.dimension, beta)
+        marginal += fourierMarginal(queries.dimension, beta, alpha)*coefficients[alpha+1]
+    end
+
+    marginal/(2^queries.dimension)
+end
+
+function Marginals(queries::Parities, h::Histogram)
+
+    marginals = []
+
+    for beta in queries.idx
+        push!(marginals, calculateMarginal(queries, h, beta))
+    end
+
+    marginals
 end
 
 function initialize(queries::Parities, data::Tabular, ps::MWParameters)
     initialize(queries, Histogram(data), ps)
 end
 
-
-type FactorParity <: FactorHistogramQuery
+struct FactorParity <: FactorHistogramQuery
     attributes::Array{Int, 1}
 end
 
@@ -59,7 +143,7 @@ end
 
 Implementation of parity queries over factored histograms.
 """
-type FactorParities <: FactorHistogramQueries
+struct FactorParities <: FactorHistogramQueries
     queries::Array{FactorParity, 1}
 end
 
@@ -71,7 +155,7 @@ function restrict(q::FactorParity, attributes::Array{Int, 1})
     idx = 0
     d = length(attributes)
     for a in q.attributes
-        i = findfirst(attributes, a)
+        i = findfirst(x -> x==a, attributes)
         idx += 2^(d-i)
     end
     HistogramQuery(hadamard_basis_vector(idx, d))
@@ -100,7 +184,7 @@ function evaluate(q::FactorParity, table::Tabular)
 end
 
 function evaluate(qs::FactorParities, table::Tabular)
-    evals = Array(Float64, length(qs.queries))
+    evals = zeros(Float64, length(qs.queries))
     @simd for i in 1:length(qs.queries)
         @inbounds evals[i] = evaluate(qs.queries[i], table)
     end

--- a/src/rangequeries.jl
+++ b/src/rangequeries.jl
@@ -1,20 +1,98 @@
 """
-    RangeQueries
+    RangeQuery
+
+Range query is a type of histogram query corresponding to an
+intervals over the domain. i -> j (1 <= i <= j <= domain).
+"""
+struct RangeQuery <: Query
+    interval::Interval
+    domain::Int # the domain size
+end
+
+"""
+    RangeQueriesRangeQueries
+
+Range queries are type of histogram query corresponding to
+intervals over the domain.
+"""
+struct RangeQueries <: Queries
+    intervals::Array{Interval, 1}
+    domain::Int # the domain size
+end
+
+"""
+    SeriesRangeQueriesRangeQueries
 
 Range queries are type of histogram query corresponding to all possible
 intervals over the domain that start with the first element.
 """
-type RangeQueries <: Queries
-    domain::Int
+struct SeriesRangeQueries <: Queries
+    domain::Int # the domain size
+end
+
+"""
+    get(interval::Interval, domain::Int64)
+
+Return 0/1 indicator vector for the interval in the size of the domain.
+"""
+function get_query_vector_from_interval(interval::Interval, domain::Int64)
+    query_vector = zeros(domain)
+    start_index, end_index = interval
+    query_vector[start_index : end_index] .= 1
+    query_vector
+end
+
+"""
+    get(query::RangeQuery)
+
+Return 0/1 indicator vector of interval [j:k] of the query. (query.interval = (j,k))
+"""
+function get(query::RangeQuery)
+    HistogramQuery(get_query_vector_from_interval(query.interval, query.domain))
 end
 
 """
     get(queries::RangeQueries, i::Int)
 
-Return -1/+1 indicator vector of interval [1:i].
+Return 0/1 indicator vector of interval [j:k] of the i'th range query (queries[i] = (j,k)).
 """
 function get(queries::RangeQueries, i::Int)
-    HistogramQuery(vcat(ones(i), -1.0*ones(queries.domain-i)))
+    HistogramQuery(get_query_vector_from_interval(queries.intervals[i], queries.domain))
+end
+
+"""
+    get(queries::RangeQueries, i::Int)
+
+Return 0/1 indicator vector of interval [1:i].
+"""
+function get(queries::SeriesRangeQueries, i::Int)
+    HistogramQuery(vcat(ones(i), zeros(queries.domain-i)))#-1.0*ones(queries.domain-i)))
+end
+
+"""
+   evaluate(query::RangeQuery, h::Histogram)
+
+Evaluate the query on the given histogram.
+"""
+function evaluate(query::RangeQuery, h::Histogram)
+    @assert query.domain == length(h.weights)
+    answer = evaluate(get(query), h)
+    answer
+end
+
+"""
+   evaluate(queries::RangeQueries, h::Histogram)
+
+Evaluate all the given range queries on the given histogram.
+"""
+function evaluate(queries::RangeQueries, h::Histogram)
+    @assert queries.domain == length(h.weights)
+    num_queries = length(queries.intervals)
+    answers = Array{Float64}(undef, num_queries)
+    @simd for j=1:num_queries
+        @inbounds answers[j] = evaluate(get(queries, j), h)
+    end
+    answers
 end
 
 """
@@ -22,13 +100,24 @@ end
 
 Evaluate all range queries on the given histogram.
 """
-function evaluate(queries::RangeQueries, h::Histogram)
+function evaluate(queries::SeriesRangeQueries, h::Histogram)
     @assert queries.domain == length(h.weights)
-    answers = Array(Float64, queries.domain)
-    running_sum = -1.0
+    answers = zeros(Float64, queries.domain)
+    running_sum = 0
     @simd for j=1:queries.domain
-        @inbounds running_sum += 2.0 * h.weights[j]
+        @inbounds running_sum += h.weights[j]
         @inbounds answers[j] = running_sum
     end
     answers
+end
+
+function queriesMatrix(queries::SeriesRangeQueries)
+
+    query_matrix = zeros(queries.domain, queries.domain)
+    @simd for i=1:queries.domain
+        @simd for j=1:i
+            @inbounds query_matrix[i,j] = 1
+        end
+    end
+    query_matrix
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using PrivateMultiplicativeWeights
 using Hadamard
-using Base.Test
+using Test
+using Random
 
 # test histogram transform
 @test Histogram(Tabular(convert(Array{Int64, 2}, zeros(1,10)))).weights == [1.0, 0.0]
@@ -20,12 +21,12 @@ for j = 0:10
 end
 
 # test range queries
-srand(1234)
+Random.seed!(1234)
 data = Histogram([0.0, 1.0, 0.0], 1000)
-@test maximum_error(mwem(RangeQueries(3), data)) < 0.1
+@test maximum_error(mwem(SeriesRangeQueries(3), data)) < 0.1
 
 # test parities
-srand(1234)
+Random.seed!(1234)
 data = Tabular([0 0 1 1; 0 0 1 1; 0 1 0 1])
 @test maximum_error(mwem(Parities(3, 2), data, MWParameters(epsilon=100.0))) < 0.1
 @test maximum_error(mwem(FactorParities(3, 2), data, MWParameters(epsilon=100.0))) < 0.1


### PR DESCRIPTION
The changes in the definitions are:
- `epsilon` is the total privacy budget instead of the budget for every step.
- `range querys` have values {0,1} instead {-1,1}.
- additional option to control how the `epsilon` budget can be split between the `iterations` and the `initialization`, and between the two parts inside iteration.

There are also additions of:
- A basic accessibility for datasets given by DataFrames, That can be expand to support more general types of data.
- Tries for appliyng parallel computing for one of the loops in the Multiplicative Weights part that create a bottleneck. It can realy speed up after improvments. 